### PR TITLE
test: Allow the use of the `-short` flag (`1K` iterations instead of `1M`)

### DIFF
--- a/uniques_test.go
+++ b/uniques_test.go
@@ -5,103 +5,108 @@ import (
 	"testing"
 )
 
-const upper = 1_000_000
+func TestUniques(t *testing.T) {
+	u := upper()
 
-func TestUniquesWithPadding(t *testing.T) {
-	minLength := len(DefaultAlphabet)
-	s, err := NewCustom(Options{
-		MinLength: &minLength,
+	t.Run("WithPadding", func(t *testing.T) {
+		minLength := len(DefaultAlphabet)
+
+		s, err := NewCustom(Options{
+			MinLength: &minLength,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		set := make(map[string]struct{})
+
+		for i := uint64(0); i < u; i++ {
+			numbers := []uint64{i}
+
+			id, _ := s.Encode(numbers)
+			set[id] = struct{}{}
+
+			decodedNumbers := s.Decode(id)
+			if !reflect.DeepEqual(numbers, decodedNumbers) {
+				t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
+			}
+		}
+
+		if len(set) != int(u) {
+			t.Errorf("Invalid set count")
+		}
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	set := make(map[string]struct{})
-
-	for i := uint64(0); i < upper; i++ {
-		numbers := []uint64{i}
-		id, _ := s.Encode(numbers)
-		set[id] = struct{}{}
-
-		decodedNumbers := s.Decode(id)
-		if !reflect.DeepEqual(numbers, decodedNumbers) {
-			t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
-		}
-	}
-
-	if len(set) != upper {
-		t.Errorf("Invalid set count")
-	}
-}
-
-func TestUniquesLowRanges(t *testing.T) {
 	s, err := New()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	set := make(map[string]struct{})
+	t.Run("LowRanges", func(t *testing.T) {
+		set := make(map[string]struct{})
 
-	for i := uint64(0); i < upper; i++ {
-		numbers := []uint64{i}
-		id, _ := s.Encode(numbers)
-		set[id] = struct{}{}
+		for i := uint64(0); i < u; i++ {
+			numbers := []uint64{i}
 
-		decodedNumbers := s.Decode(id)
-		if !reflect.DeepEqual(numbers, decodedNumbers) {
-			t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
+			id, _ := s.Encode(numbers)
+			set[id] = struct{}{}
+
+			decodedNumbers := s.Decode(id)
+			if !reflect.DeepEqual(numbers, decodedNumbers) {
+				t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
+			}
 		}
-	}
 
-	if len(set) != upper {
-		t.Errorf("Invalid set count")
-	}
+		if len(set) != int(u) {
+			t.Errorf("Invalid set count")
+		}
+	})
+
+	t.Run("HighRanges", func(t *testing.T) {
+		set := make(map[string]struct{})
+
+		for i := uint64(100_000_000); i < 100_000_000+u; i++ {
+			numbers := []uint64{i}
+
+			id, _ := s.Encode(numbers)
+			set[id] = struct{}{}
+
+			decodedNumbers := s.Decode(id)
+			if !reflect.DeepEqual(numbers, decodedNumbers) {
+				t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
+			}
+		}
+
+		if len(set) != int(u) {
+			t.Errorf("Invalid set count")
+		}
+	})
+
+	t.Run("Multi", func(t *testing.T) {
+		set := make(map[string]struct{})
+
+		for i := uint64(0); i < u; i++ {
+			numbers := []uint64{i, i, i, i, i}
+
+			id, _ := s.Encode(numbers)
+			set[id] = struct{}{}
+
+			decodedNumbers := s.Decode(id)
+			if !reflect.DeepEqual(numbers, decodedNumbers) {
+				t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
+			}
+		}
+
+		if len(set) != int(u) {
+			t.Errorf("Invalid set count")
+		}
+	})
 }
 
-func TestUniquesHighRanges(t *testing.T) {
-	s, err := New()
-	if err != nil {
-		t.Fatal(err)
+func upper() uint64 {
+	if testing.Short() {
+		return 1_000
 	}
 
-	set := make(map[string]struct{})
-
-	for i := uint64(100_000_000); i < 100_000_000+upper; i++ {
-		numbers := []uint64{i}
-		id, _ := s.Encode(numbers)
-		set[id] = struct{}{}
-
-		decodedNumbers := s.Decode(id)
-		if !reflect.DeepEqual(numbers, decodedNumbers) {
-			t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
-		}
-	}
-
-	if len(set) != upper {
-		t.Errorf("Invalid set count")
-	}
-}
-
-func TestUniquesMulti(t *testing.T) {
-	s, err := New()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	set := make(map[string]struct{})
-
-	for i := uint64(0); i < upper; i++ {
-		numbers := []uint64{i, i, i, i, i}
-		id, _ := s.Encode(numbers)
-		set[id] = struct{}{}
-
-		decodedNumbers := s.Decode(id)
-		if !reflect.DeepEqual(numbers, decodedNumbers) {
-			t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
-		}
-	}
-
-	if len(set) != upper {
-		t.Errorf("Invalid set count")
-	}
+	return 1_000_000
 }


### PR DESCRIPTION
In order to significantly reduce the runtime of the test suite the `-short` flag can now be used _(when running the whole set of uniques test cases are not desired)_

```
$ time go test -short ./...
ok  	github.com/sqids/sqids-go	0.446s

real	0m0.559s
user	0m0.688s
sys	0m0.113s
```

Also combine the tests into subtests under `TestUniques`