### PR TITLE
test: Add BenchmarkEncodeDecode

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -5,6 +5,27 @@ import (
 	"testing"
 )
 
+func BenchmarkEncodeDecode(b *testing.B) {
+	numbers := []uint64{1, 2, 3, 4, 5}
+
+	s, err := New()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		id, err := s.Encode(numbers)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		decodedNumbers := s.Decode(id)
+		if !reflect.DeepEqual(numbers, decodedNumbers) {
+			b.Errorf("Could not encode/decode `%v`", numbers)
+		}
+	}
+}
+
 func TestEncodingSimple(t *testing.T) {
 	numbers := []uint64{1, 2, 3}
 

--- a/sqids.go
+++ b/sqids.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"strings"
 )
 
@@ -332,7 +331,6 @@ func contains(slice []string, str string) bool {
 
 func (s *Sqids) isBlockedID(id string) bool {
 	id = strings.ToLower(id)
-	r := regexp.MustCompile(`\d`)
 
 	for _, word := range s.blocklist {
 		if len(word) <= len(id) {
@@ -340,13 +338,23 @@ func (s *Sqids) isBlockedID(id string) bool {
 				if id == word {
 					return true
 				}
-			} else if r.MatchString(word) {
+			} else if hasDigit(word) {
 				if strings.HasPrefix(id, word) || strings.HasSuffix(id, word) {
 					return true
 				}
 			} else if strings.Contains(id, word) {
 				return true
 			}
+		}
+	}
+
+	return false
+}
+
+func hasDigit(word string) bool {
+	for _, r := range word {
+		if r >= '0' && r <= '9' {
+			return true
 		}
 	}
 


### PR DESCRIPTION
Initial benchmarking of `sqids.Encode` and `sqids.Decode` for the input `[]uint64{1, 2, 3, 4, 5}` on my particular machine gives me these numbers:
```sh
$ time go test -bench=. -run=BenchmarkEncodeDecode -benchmem -cpuprofile profile.out
goos: linux
goarch: amd64
pkg: github.com/sqids/sqids-go
cpu: Intel(R) Core(TM) i7-10700T CPU @ 2.00GHz
BenchmarkEncodeDecode-16    	   12253	     97055 ns/op	   32470 B/op	     124 allocs/op
PASS
ok  	github.com/sqids/sqids-go	2.214s

real	0m2.370s
user	0m2.299s
sys	0m0.175s
```

**pprof** shows us that a lot of unnecessary time is spent in dealing with a regular expression:
![pprof001](https://github.com/sqids/sqids-go/assets/565124/ce6c318c-5f0a-4d28-97e9-8e3a12a82ec7)

> [!Note]
> (Re-)Compilation (and usage) of regular expressions are pretty slow in Go, so should be avoided if possible.