### PR TITLE
`Options` are no longer pointers, variadic `New`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,8 @@ numbers := s.Decode(id) // [1, 2, 3]
 Randomize IDs by providing a custom alphabet:
 
 ```golang
-alphabet := "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE"
-s, _ := sqids.NewCustom(sqids.Options{
-    Alphabet: &alphabet,
+s, _ := sqids.New(sqids.Options{
+    Alphabet: "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE",
 })
 id, _ := s.Encode([]uint64{1, 2, 3}) // "B5aMa3"
 numbers := s.Decode(id) // [1, 2, 3]
@@ -72,9 +71,8 @@ numbers := s.Decode(id) // [1, 2, 3]
 Enforce a *minimum* length for IDs:
 
 ```golang
-minLength := 10
-s, _ := sqids.NewCustom(sqids.Options{
-    MinLength: &minLength,
+s, _ := sqids.New(sqids.Options{
+    MinLength: 10,
 })
 id, _ := s.Encode([]uint64{1, 2, 3}) // "75JT1cd0dL"
 numbers := s.Decode(id) // [1, 2, 3]
@@ -83,8 +81,8 @@ numbers := s.Decode(id) // [1, 2, 3]
 Prevent specific words from appearing anywhere in the auto-generated IDs:
 
 ```golang
-s, _ := sqids.NewCustom(sqids.Options{
-    Blocklist: &[]string{"word1", "word2"},
+s, _ := sqids.New(sqids.Options{
+    Blocklist: []string{"word1", "word2"},
 })
 id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
 numbers := s.Decode(id) // [1, 2, 3]

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ import "github.com/sqids/sqids-go"
 
 Simple encode & decode:
 
-```golang
-s, _ := sqids.New()
-id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
-numbers := s.Decode(id) // [1, 2, 3]
+[embedmd]:# (examples/sqids-encode-decode/sqids-encode-decode.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+```go
+	s, _ := sqids.New()
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
+	numbers := s.Decode(id)              // [1, 2, 3]
 ```
 
 > **Note**
@@ -60,32 +61,35 @@ numbers := s.Decode(id) // [1, 2, 3]
 
 Randomize IDs by providing a custom alphabet:
 
-```golang
-s, _ := sqids.New(sqids.Options{
-    Alphabet: "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE",
-})
-id, _ := s.Encode([]uint64{1, 2, 3}) // "B5aMa3"
-numbers := s.Decode(id) // [1, 2, 3]
+[embedmd]:# (examples/sqids-custom-alphabet/sqids-custom-alphabet.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+```go
+	s, _ := sqids.New(sqids.Options{
+		Alphabet: "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE",
+	})
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "B5aMa3"
+	numbers := s.Decode(id)              // [1, 2, 3]
 ```
 
 Enforce a *minimum* length for IDs:
 
-```golang
-s, _ := sqids.New(sqids.Options{
-    MinLength: 10,
-})
-id, _ := s.Encode([]uint64{1, 2, 3}) // "75JT1cd0dL"
-numbers := s.Decode(id) // [1, 2, 3]
+[embedmd]:# (examples/sqids-minimum-length/sqids-minimum-length.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+```go
+	s, _ := sqids.New(sqids.Options{
+		MinLength: 10,
+	})
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "75JT1cd0dL"
+	numbers := s.Decode(id)              // [1, 2, 3]
 ```
 
 Prevent specific words from appearing anywhere in the auto-generated IDs:
 
-```golang
-s, _ := sqids.New(sqids.Options{
-    Blocklist: []string{"word1", "word2"},
-})
-id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
-numbers := s.Decode(id) // [1, 2, 3]
+[embedmd]:# (examples/sqids-blocklist/sqids-blocklist.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+```go
+	s, _ := sqids.New(sqids.Options{
+		Blocklist: []string{"word1", "word2"},
+	})
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
+	numbers := s.Decode(id)              // [1, 2, 3]
 ```
 
 ## 📝 License

--- a/alphabet_test.go
+++ b/alphabet_test.go
@@ -10,8 +10,8 @@ func TestAlphabetSimple(t *testing.T) {
 	id := "4d9fd2"
 
 	alphabet := "0123456789abcdef"
-	s, err := NewCustom(Options{
-		Alphabet: &alphabet,
+	s, err := New(Options{
+		Alphabet: alphabet,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -33,9 +33,8 @@ func TestAlphabetSimple(t *testing.T) {
 }
 
 func TestAlphabetShort(t *testing.T) {
-	alphabet := "abcde"
-	s, err := NewCustom(Options{
-		Alphabet: &alphabet,
+	s, err := New(Options{
+		Alphabet: "abcde",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -55,9 +54,8 @@ func TestAlphabetShort(t *testing.T) {
 }
 
 func TestAlphabetLong(t *testing.T) {
-	alphabet := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_+|{}[];:'\"/?.>,<`~"
-	s, err := NewCustom(Options{
-		Alphabet: &alphabet,
+	s, err := New(Options{
+		Alphabet: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_+|{}[];:'\"/?.>,<`~",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -77,18 +75,16 @@ func TestAlphabetLong(t *testing.T) {
 }
 
 func TestRepeatingAlphabetCharacters(t *testing.T) {
-	alphabet := "aabcdefg"
-	if _, err := NewCustom(Options{
-		Alphabet: &alphabet,
+	if _, err := New(Options{
+		Alphabet: "aabcdefg",
 	}); err == nil {
 		t.Errorf("Should not accept alphabet with repeating characters")
 	}
 }
 
 func TestTooShortOfAnAlphabet(t *testing.T) {
-	alphabet := "abcd"
-	if _, err := NewCustom(Options{
-		Alphabet: &alphabet,
+	if _, err := New(Options{
+		Alphabet: "abcd",
 	}); err == nil {
 		t.Errorf("Should not accept too short of an alphabet")
 	}

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -48,8 +48,8 @@ func TestBlocklistEmpty(t *testing.T) {
 	numbers := []uint64{200044}
 	id := "sexy"
 
-	s, err := NewCustom(Options{
-		Blocklist: &[]string{},
+	s, err := New(Options{
+		Blocklist: []string{},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -73,8 +73,8 @@ func TestBlocklistNonEmpty(t *testing.T) {
 	numbers := []uint64{200044}
 	id := "sexy"
 
-	s, err := NewCustom(Options{
-		Blocklist: &[]string{
+	s, err := New(Options{
+		Blocklist: []string{
 			"AvTg", // originally encoded [100000]
 		},
 	})
@@ -87,10 +87,12 @@ func TestBlocklistNonEmpty(t *testing.T) {
 	if !reflect.DeepEqual(numbers, decodedNumbers) {
 		t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, numbers, decodedNumbers)
 	}
+
 	generatedID, err := s.Encode(numbers)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if id != generatedID {
 		t.Errorf("Encoding `%v` should produce `%v`, but instead produced `%v`", numbers, id, generatedID)
 	}
@@ -100,25 +102,28 @@ func TestBlocklistNonEmpty(t *testing.T) {
 	if !reflect.DeepEqual([]uint64{100_000}, decodedNumbers) {
 		t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, []uint64{100_000}, decodedNumbers)
 	}
+
 	generatedID, err = s.Encode([]uint64{100_000})
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if generatedID != "7T1X8k" {
 		t.Errorf("Encoding `%v` should produce `%v`, but instead produced `%v`", []uint64{100_000}, "7T1X8k", generatedID)
 	}
+
 	decodedNumbers = s.Decode("7T1X8k")
 	if !reflect.DeepEqual([]uint64{100_000}, decodedNumbers) {
 		t.Errorf("Decoding `%v` should produce `%v`, but instead produced `%v`", id, []uint64{100_000}, decodedNumbers)
 	}
 }
 
-func TestNewCustomBlocklist(t *testing.T) {
+func TestNewBlocklist(t *testing.T) {
 	numbers := []uint64{1, 2, 3}
 	id := "TM0x1Mxz"
 
-	s, err := NewCustom(Options{
-		Blocklist: &[]string{
+	s, err := New(Options{
+		Blocklist: []string{
 			"8QRLaD",   // normal result of 1st encoding, let's block that word on purpose
 			"7T1cd0dL", // result of 2nd encoding
 			"UeIe",     // result of 3rd encoding is `RA8UeIe7`, let's block a substring
@@ -134,6 +139,7 @@ func TestNewCustomBlocklist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if id != generatedID {
 		t.Errorf("Encoding `%v` should produce `%v`, but instead produced `%v`", numbers, id, generatedID)
 	}
@@ -146,12 +152,10 @@ func TestNewCustomBlocklist(t *testing.T) {
 
 func TestDecodingBlocklistedIDs(t *testing.T) {
 	numbers := []uint64{1, 2, 3}
-	blocklist := []string{
-		"8QRLaD", "7T1cd0dL", "RA8UeIe7", "WM3Limhw", "LfUQh4HN",
-	}
+	blocklist := []string{"8QRLaD", "7T1cd0dL", "RA8UeIe7", "WM3Limhw", "LfUQh4HN"}
 
-	s, err := NewCustom(Options{
-		Blocklist: &blocklist,
+	s, err := New(Options{
+		Blocklist: blocklist,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -168,9 +172,10 @@ func TestDecodingBlocklistedIDs(t *testing.T) {
 func TestShortBlocklistMatch(t *testing.T) {
 	numbers := []uint64{1_000}
 
-	s, err := NewCustom(Options{
-		Blocklist: &[]string{"pPQ"},
+	s, err := New(Options{
+		Blocklist: []string{"pPQ"},
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,10 +195,9 @@ func TestUpperCaseAlphabetBlocklistFiltering(t *testing.T) {
 	numbers := []uint64{1, 2, 3}
 	id := "ULPBZGBM"
 
-	alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	s, err := NewCustom(Options{
-		Alphabet:  &alphabet,
-		Blocklist: &[]string{"sqnmpn"}, // lowercase blocklist in only-uppercase alphabet
+	s, err := New(Options{
+		Alphabet:  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		Blocklist: []string{"sqnmpn"}, // lowercase blocklist in only-uppercase alphabet
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -46,7 +46,7 @@ func TestEncodingSimple(t *testing.T) {
 }
 
 func TestEncodingDifferentInputs(t *testing.T) {
-	numbers := []uint64{0, 0, 0, 1, 2, 3, 100, 1_000, 100_000, 1_000_000, MaxValue()}
+	numbers := []uint64{minUint64Value, 0, 0, 1, 2, 3, 100, 1_000, 100_000, 1_000_000, maxUint64Value}
 
 	s, err := New()
 	if err != nil {

--- a/examples/sqids-blocklist/sqids-blocklist.go
+++ b/examples/sqids-blocklist/sqids-blocklist.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sqids/sqids-go"
+)
+
+func main() {
+	s, _ := sqids.New(sqids.Options{
+		Blocklist: []string{"word1", "word2"},
+	})
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
+	numbers := s.Decode(id)              // [1, 2, 3]
+
+	fmt.Println(id, numbers)
+}

--- a/examples/sqids-custom-alphabet/sqids-custom-alphabet.go
+++ b/examples/sqids-custom-alphabet/sqids-custom-alphabet.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sqids/sqids-go"
+)
+
+func main() {
+	s, _ := sqids.New(sqids.Options{
+		Alphabet: "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE",
+	})
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "B5aMa3"
+	numbers := s.Decode(id)              // [1, 2, 3]
+
+	fmt.Println(id, numbers)
+}

--- a/examples/sqids-encode-decode/sqids-encode-decode.go
+++ b/examples/sqids-encode-decode/sqids-encode-decode.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sqids/sqids-go"
+)
+
+func main() {
+	s, _ := sqids.New()
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
+	numbers := s.Decode(id)              // [1, 2, 3]
+
+	fmt.Println(id, numbers)
+}

--- a/examples/sqids-minimum-length/sqids-minimum-length.go
+++ b/examples/sqids-minimum-length/sqids-minimum-length.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sqids/sqids-go"
+)
+
+func main() {
+	s, _ := sqids.New(sqids.Options{
+		MinLength: 10,
+	})
+	id, _ := s.Encode([]uint64{1, 2, 3}) // "75JT1cd0dL"
+	numbers := s.Decode(id)              // [1, 2, 3]
+
+	fmt.Println(id, numbers)
+}

--- a/minlength_test.go
+++ b/minlength_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 func TestMinLengthSimple(t *testing.T) {
-	minLength := len(defaultAlphabet)
-	s, err := NewCustom(Options{
-		MinLength: &minLength,
+	s, err := New(Options{
+		MinLength: len(defaultAlphabet),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	numbers := []uint64{1, 2, 3}
+
 	id := "75JILToVsGerOADWmHlY38xvbaNZKQ9wdFS0B6kcMEtnRpgizhjU42qT1cd0dL"
 
 	generatedID, err := s.Encode(numbers)
@@ -33,9 +33,8 @@ func TestMinLengthSimple(t *testing.T) {
 }
 
 func TestMinLengthIncrementalNumbers(t *testing.T) {
-	minLength := len(defaultAlphabet)
-	s, err := NewCustom(Options{
-		MinLength: &minLength,
+	s, err := New(Options{
+		MinLength: len(defaultAlphabet),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -74,16 +73,16 @@ func TestMinLengthIncrementalNumbers(t *testing.T) {
 func TestMinLengths(t *testing.T) {
 	for _, minLength := range []int{0, 1, 5, 10, len(defaultAlphabet)} {
 		for _, numbers := range [][]uint64{
-			{MinValue()},
+			{minUint64Value},
 			{0, 0, 0, 0, 0},
 			{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			{100, 200, 300},
 			{1000, 2000, 3000},
 			{1000000},
-			{MaxValue()},
+			{maxUint64Value},
 		} {
-			s, err := NewCustom(Options{
-				MinLength: &minLength,
+			s, err := New(Options{
+				MinLength: minLength,
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -93,6 +92,7 @@ func TestMinLengths(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			if len(generatedID) < minLength {
 				t.Errorf("Encoding `%v` with min length `%v` produced `%v`", numbers, minLength, generatedID)
 			}
@@ -106,16 +106,14 @@ func TestMinLengths(t *testing.T) {
 }
 
 func TestOutOfRangeInvalidMinLength(t *testing.T) {
-	minLength := -1
-	if _, err := NewCustom(Options{
-		MinLength: &minLength,
+	if _, err := New(Options{
+		MinLength: -1,
 	}); err == nil {
 		t.Errorf("Should not allow out of range min length")
 	}
 
-	minLength = len(defaultAlphabet) + 1
-	if _, err := NewCustom(Options{
-		MinLength: &minLength,
+	if _, err := New(Options{
+		MinLength: len(defaultAlphabet) + 1,
 	}); err == nil {
 		t.Errorf("Should not allow out of range min length")
 	}

--- a/sqids.go
+++ b/sqids.go
@@ -1,5 +1,7 @@
 package sqids
 
+//go:generate go run github.com/campoy/embedmd/v2@v2.0.0 -w README.md
+
 import (
 	"errors"
 	"fmt"

--- a/sqids_test.go
+++ b/sqids_test.go
@@ -1,0 +1,15 @@
+package sqids
+
+import "testing"
+
+func TestMinValue(t *testing.T) {
+	if got, want := MinValue(), uint64(0); got != want {
+		t.Fatalf("MinValue() = %d, want %d", got, want)
+	}
+}
+
+func TestMaxValue(t *testing.T) {
+	if got, want := MaxValue(), uint64(18446744073709551615); got != want {
+		t.Fatalf("MaxValue() = %d, want %d", got, want)
+	}
+}

--- a/uniques_test.go
+++ b/uniques_test.go
@@ -9,10 +9,8 @@ func TestUniques(t *testing.T) {
 	u := upper()
 
 	t.Run("WithPadding", func(t *testing.T) {
-		minLength := len(defaultAlphabet)
-
-		s, err := NewCustom(Options{
-			MinLength: &minLength,
+		s, err := New(Options{
+			MinLength: len(defaultAlphabet),
 		})
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
🔥 Removed no longer needed `NewCustom` and check for `inRangeNumbers` in `Encode` _(since a `[]uint64` can only contain `0` or more `uint64` values, all of which are valid to encode)_

Updated examples i `README`, should better align with JavaScript implementation now that we do not have to have a separate `NewCustom` constructor.

I'm also introducing verifiable code in the `README` (using [embedmd](https://github.com/campoy/embedmd)) in order to more easily keep the examples up to date.

## Changes

- [X] `Options` are no longer pointers, variadic `New`
- [X] examples: Add initial examples for use in the `README`