### PR TITLE
test: Use a build matrix in GitHub Actions, run tests for `1.20.x` and `1.21.x`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,17 @@
-name: tests
 on: [push, pull_request]
+name: tests
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.21.x, 1.20.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20.x'
-      - name: Install dependencies
-        run: go get .
-      - name: Build
-        run: go build -v ./...
-      - name: Test with the Go CLI
-        run: go test
+          go-version: ${{ matrix.go-version }}
+      - name: Run Go tests
+        run: go test -v -short ./...


### PR DESCRIPTION
🔥 Do not also build _(since the test binaries are being built, no need to do it twice)_
✨ Also add use of `-short` flag to make the test runs significantly faster _(at least for now)_