### PR TITLE
doc: Update embedmd regular expressions so that GitHub hides them correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import "github.com/sqids/sqids-go"
 
 Simple encode & decode:
 
-[embedmd]:# (examples/sqids-encode-decode/sqids-encode-decode.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+[embedmd]:# (examples/sqids-encode-decode/sqids-encode-decode.go /.+sqids.New/ /\[1, 2, 3\]/)
 ```go
 	s, _ := sqids.New()
 	id, _ := s.Encode([]uint64{1, 2, 3}) // "8QRLaD"
@@ -61,7 +61,7 @@ Simple encode & decode:
 
 Randomize IDs by providing a custom alphabet:
 
-[embedmd]:# (examples/sqids-custom-alphabet/sqids-custom-alphabet.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+[embedmd]:# (examples/sqids-custom-alphabet/sqids-custom-alphabet.go /.+sqids.New/ /\[1, 2, 3\]/)
 ```go
 	s, _ := sqids.New(sqids.Options{
 		Alphabet: "FxnXM1kBN6cuhsAvjW3Co7l2RePyY8DwaU04Tzt9fHQrqSVKdpimLGIJOgb5ZE",
@@ -72,7 +72,7 @@ Randomize IDs by providing a custom alphabet:
 
 Enforce a *minimum* length for IDs:
 
-[embedmd]:# (examples/sqids-minimum-length/sqids-minimum-length.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+[embedmd]:# (examples/sqids-minimum-length/sqids-minimum-length.go /.+sqids.New/ /\[1, 2, 3\]/)
 ```go
 	s, _ := sqids.New(sqids.Options{
 		MinLength: 10,
@@ -83,7 +83,7 @@ Enforce a *minimum* length for IDs:
 
 Prevent specific words from appearing anywhere in the auto-generated IDs:
 
-[embedmd]:# (examples/sqids-blocklist/sqids-blocklist.go /(.+)sqids.New/ /\[1, 2, 3\]/)
+[embedmd]:# (examples/sqids-blocklist/sqids-blocklist.go /.+sqids.New/ /\[1, 2, 3\]/)
 ```go
 	s, _ := sqids.New(sqids.Options{
 		Blocklist: []string{"word1", "word2"},


### PR DESCRIPTION
Remove parens in regular expressions since GitHub fails to parse them