### PR TITLE
Use `[]rune` instead of `string` in `Encode`/`Decode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+profile.out
+sqids-go.test

--- a/sqids_test.go
+++ b/sqids_test.go
@@ -13,3 +13,32 @@ func TestMaxValue(t *testing.T) {
 		t.Fatalf("MaxValue() = %d, want %d", got, want)
 	}
 }
+
+func TestCalculateOffset(t *testing.T) {
+	for _, tt := range []struct {
+		alphabet string
+		numbers  []uint64
+		want     int
+	}{
+		{"", []uint64{}, -1},
+		{"", []uint64{0}, -1},
+		{"abcde", []uint64{0}, 3},
+		{"fghij", []uint64{0}, 3},
+		{"abcde", []uint64{1}, 4},
+		{"abcde", []uint64{2}, 0},
+		{defaultAlphabet, []uint64{24}, 60},
+		{defaultAlphabet, []uint64{25}, 61},
+		{defaultAlphabet, []uint64{26}, 4},
+		{defaultAlphabet, []uint64{27}, 5},
+		{defaultAlphabet, []uint64{1, 2, 3}, 55},
+		{defaultAlphabet, []uint64{4, 5, 6}, 2},
+	} {
+		if _, err := New(Options{Alphabet: tt.alphabet}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := calculateOffset(tt.alphabet, tt.numbers); got != tt.want {
+			t.Fatalf("calculateOffset(%q, %#v) = %d, want %d", tt.alphabet, tt.numbers, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
- [X] git: Ignore `profile.out` and `sqids-go.test`
- [X] Use `[]rune` instead of `string` in `Encode`/`Decode`

> **Note**
> With this change it would be possible to support multibyte characters in alphabets if it was allowed by the spec.


### Benchmark

```
$ time go test -bench=. -run=BenchmarkEncodeDecode -benchmem -cpuprofile profile.out
goos: linux
goarch: amd64
pkg: github.com/sqids/sqids-go
cpu: Intel(R) Core(TM) i7-10700T CPU @ 2.00GHz
BenchmarkEncodeDecode-16    	   30134	     38607 ns/op	   16648 B/op	     132 allocs/op
PASS
ok  	github.com/sqids/sqids-go	1.711s

real	0m1.929s
user	0m1.971s
sys	0m0.183s
```