### PR TITLE
bug: Fix decode `panic` for invalid input

### DIFF
--- a/sqids.go
+++ b/sqids.go
@@ -230,7 +230,11 @@ func (s *Sqids) Decode(id string) []uint64 {
 			}
 		}
 
-		rid = joinRuneSlices(chunks[1:], separator)
+		if len(chunks) > 0 {
+			rid = joinRuneSlices(chunks[1:], separator)
+		} else {
+			return []uint64{}
+		}
 	}
 
 	return ret

--- a/sqids_test.go
+++ b/sqids_test.go
@@ -42,3 +42,18 @@ func TestCalculateOffset(t *testing.T) {
 		}
 	}
 }
+
+func TestDecode(t *testing.T) {
+	s, err := New()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := len(s.Decode("Re")), 0; got != want {
+		t.Fatalf(`len(s.Decode("Re")) = %d, want %d`, got, want)
+	}
+
+	if got, want := len(s.Decode("U9")), 1; got != want {
+		t.Fatalf(`len(s.Decode("U9")) = %d, want %d`, got, want)
+	}
+}


### PR DESCRIPTION
Trying to decode an invalid ID such as "Re" using the default alphabet resulted in a panic in `v0.3.3`, this change should solve that isssue.