### PR TITLE
Move `minUint64Value` and `maxUint64Value` constants to encoding test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 name: tests
 jobs:
   build:

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,8 +1,14 @@
 package sqids
 
 import (
+	"math"
 	"reflect"
 	"testing"
+)
+
+const (
+	minUint64Value = uint64(0)
+	maxUint64Value = uint64(math.MaxUint64)
 )
 
 func BenchmarkEncodeDecode(b *testing.B) {

--- a/sqids.go
+++ b/sqids.go
@@ -4,15 +4,12 @@ package sqids
 
 import (
 	"errors"
-	"math"
 	"strings"
 )
 
 const (
 	defaultAlphabet   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	minAlphabetLength = 3
-	minUint64Value    = uint64(0)
-	maxUint64Value    = uint64(math.MaxUint64)
 )
 
 var defaultBlocklist []string = newDefaultBlocklist()


### PR DESCRIPTION
Constants are no longer used outside of the tests, so move them away from `sqids.go`